### PR TITLE
Adding PS1 for GDS setup (with Dumps)

### DIFF
--- a/scripts/fourohandbeyond/windows/Setup-Windows-Single-Gds.ps1
+++ b/scripts/fourohandbeyond/windows/Setup-Windows-Single-Gds.ps1
@@ -8,7 +8,8 @@ Write-Host " / /|  /  __/ /_/ /__  __/ /  " -ForegroundColor Magenta
 Write-Host "/_/ |_/\___/\____/  /_/_/ /   " -ForegroundColor Yellow
 Write-Host "                     /___/    " -ForegroundColor Cyan
 Write-Host "                              "
-Write-Host "        SINGLE EDITION        " -ForegroundColor DarkRed -BackgroundColor Yellow -NoNewline; 
+Write-Host "       SINGLE INSTANCE        " -ForegroundColor DarkRed -BackgroundColor Yellow; 
+Write-Host "         GDS EDITION          " -ForegroundColor DarkRed -BackgroundColor Yellow -NoNewline; 
 Write-Host "`n";
 
 if($Stage -eq "" -or $Stage -eq "scripts"){
@@ -20,6 +21,7 @@ if($Stage -eq "" -or $Stage -eq "scripts"){
     $scriptNames = (
         "version.ps1",
         "download.ps1",
+        "downloadDumps.ps1",
         "unpack.ps1",
         "settings.ps1",
         "start.ps1",
@@ -42,13 +44,15 @@ if($Stage -eq "" -or $Stage -eq "scripts"){
     Write-Host "`nScripts download complete!" -ForegroundColor Green
 }
 
+
+
 Write-Host "Setting Execution Policy ... " -NoNewline
 Set-ExecutionPolicy Bypass -Scope CurrentUser
 Write-Host "Done!" -ForegroundColor Green
 
 if($Stage -eq "" -or $Stage -eq "download"){
     ./scripts/download.ps1
-    Write-Host "`n`nIf you saw any error messages above press " -NoNewLine; Write-Host "CTRL+C" -ForegroundColor Green -NoNewLine; Write-Host " and try to redownload, then run: '.\Setup-Windows-Single.ps1 -Stage unpack' to continue."
+    Write-Host "`n`nIf you saw any error messages above press " -NoNewLine; Write-Host "CTRL+C" -ForegroundColor Green -NoNewLine; Write-Host " and try to redownload, then run: '.\Setup-Windows-Single-Gds.ps1 -Stage unpack' to continue."
     Write-Host "To redownload any of the files specifically, run:"
     Write-Host "`t.\scripts\download.ps1 <name>" -ForegroundColor Yellow -NoNewline; Write-Host " where " -NoNewline; Write-Host "<name>" -ForegroundColor Yellow -NoNewline; Write-Host " can be one of: " -NoNewline; Write-Host "neo4j,jre,apoc,apocnlp,apocmongodb,gds" -ForegroundColor Yellow
     Write-Host "`nOtherwise - Press " -NoNewLine; Write-Host "ENTER" -NoNewLine -ForegroundColor Green; Write-Host " to continue.";
@@ -70,6 +74,19 @@ if($Stage -eq "" -or $Stage -eq "settings"){
     $Stage = ""
 }
 
-if($Start -eq "true"){
-    ./scripts/start.ps1
+Write-Host "Starting Neo4j in a new Window... (Required to load the dumps)"
+$process = Get-Process -Id $PID | Select-Object -ExpandProperty ProcessName 
+Start-Process $process -ArgumentList "-command .\scripts\start.ps1"
+Write-Host "`nPlease wait for Neo4j to say 'Started' then press " -NoNewLine; Write-Host "ENTER" -NoNewLine -ForegroundColor Green; Write-Host " to continue.";
+$_ = Read-Host
+
+if($Stage -eq "" -or $Stage -eq "dumps"){
+    ./scripts/downloadDumps.ps1 -password $Password
+    Write-Host "`n`nIf you saw any error messages above press " -NoNewLine; Write-Host "CTRL+C" -ForegroundColor Green -NoNewLine; Write-Host " and try to redownload."
+    Write-Host "To redownload any of the files specifically, run:"
+    Write-Host "`t.\scripts\downloadDumps.ps1 <name>" -ForegroundColor Yellow -NoNewline; Write-Host " where " -NoNewline; Write-Host "<name>" -ForegroundColor Yellow -NoNewline; Write-Host " can be one of: " -NoNewline; Write-Host "got,paysim" -ForegroundColor Yellow
+    Write-Host "`nOtherwise - Press " -NoNewLine; Write-Host "ENTER" -NoNewLine -ForegroundColor Green; Write-Host " to continue.";
+    $_ = Read-Host
 }
+
+Write-Host "GDS Setup is complete. You can stop your Neo4j instance now if you want. Or get GDSing!!"

--- a/scripts/fourohandbeyond/windows/download.ps1
+++ b/scripts/fourohandbeyond/windows/download.ps1
@@ -1,19 +1,12 @@
 param($product="")
 $product = $product.ToLower()
 
-function DownloadFile([string] $name, [string] $url, [string] $path){
-    Write-Host $name -ForegroundColor Cyan -NoNewLine; Write-Host " to:" $path " ... " -NoNewline;
-    try {
-        (New-Object System.Net.WebClient).DownloadFile($url, $path)
-        Write-Host "Done!" -ForegroundColor Green
-    } catch { Write-Host "Failed!" -ForegroundColor Red}
-}
+# Imports
+. .\scripts\version.ps1
+. .\scripts\functions.ps1
 
 # Opening statement
 Write-Host "Downloading - there is no progress indicator! Please be patient!" -ForegroundColor Cyan
-
-# Version
-. .\scripts\version.ps1
 
 # Files
 $jreZip = "zulu$($zuluVersion)-ca-jre$($jreVersion)-win_x64.zip"

--- a/scripts/fourohandbeyond/windows/downloadDumps.ps1
+++ b/scripts/fourohandbeyond/windows/downloadDumps.ps1
@@ -1,0 +1,52 @@
+param($Dump="", $Password="trinity")
+$Dump = $Dump.ToLower()
+
+# Imports
+. .\scripts\functions.ps1
+
+# Constants
+$rootUri = "https://github.com/tomgeudens/practical-neo4j/raw/master/data"
+
+# Opening statement
+Write-Host "When downloading the dumps - there is no progress indicator! Please be patient!" -ForegroundColor Cyan
+
+# Setup the Dumps to get, add new ones to the end of the list
+$toGet = @()
+
+# Game of Thrones Dataset
+$toGet += [PsCustomObject] @{
+    Id = 'got' # This is the Identifier used to download specific versions - i.e. if you only want the Game Of Thrones dataset - you can use 'DownloadDumps.ps1 -dump got'
+    Name = "gds_gameofthrones.dump" # Name of the dump file
+    Uri = $rooturi # The root URI, this is set at the top of the file
+    Path = (Get-Location).Path + '\dump\' # Default location to store dump files
+    Database = "gameofthrones" # The name of the database to associate with the dump file
+    ExpectedNodes = 2642 # The expected number of Nodes in the database
+}
+
+# Paysim Dataset
+$toGet += [PsCustomObject] @{
+    Id = "paysim"
+    Name = "gds_paysim.dump"
+    Uri = $rooturi
+    Path = (Get-Location).Path + '\dump\'
+    Database = "paysim"
+    ExpectedNodes = 332948
+}
+
+# Create install folder
+Write-Host "Creating 'dump' folder ... " -NoNewline;
+mkdir dump -Force | Out-Null
+Write-Host "Done!" -ForegroundColor Green
+
+# Download, Load and Check each dump
+foreach ($item in $toGet) {
+    if($Dump -eq "" -or -$Dump -eq $item.Id) {
+        DownloadFileUsingGetFileInfo $item
+        LoadDump $item
+        CreateDumpDatabase $item
+        ValidateLoading $item
+    }
+}
+
+# All done
+Write-Host "`nDownloading Dumps Complete" -ForegroundColor Green

--- a/scripts/fourohandbeyond/windows/functions.ps1
+++ b/scripts/fourohandbeyond/windows/functions.ps1
@@ -1,5 +1,5 @@
 # Imports
-if($neo4jVersion -eq ""){
+if($null -eq $neo4jVersion){
     . .\scripts\version.ps1
 }
 

--- a/scripts/fourohandbeyond/windows/functions.ps1
+++ b/scripts/fourohandbeyond/windows/functions.ps1
@@ -1,0 +1,156 @@
+# Imports
+if($neo4jVersion -eq ""){
+    . .\scripts\version.ps1
+}
+
+# Constants
+$neo4jLocation = Join-Path (Get-Location).Path "neo4j-enterprise-$($neo4jVersion)"
+
+function DownloadFileUsingGetFileInfo {
+    <#
+        .SYNOPSIS 
+            Downloads a file 
+        
+        .PARAMETER GetFileInfo
+            An object containing at least 3 properties: 
+            * Name - the name of the file to download
+            * Uri - the URI (without the Name) of the file
+            * Path - The path to download the file to (without the Name)
+
+        .INPUTS
+            PsObject
+        
+        .OUTPUTS
+            PSCustomObject
+    #>
+
+    param (
+        [Parameter(Mandatory)]
+        [PsObject] $GetFileInfo
+    )
+
+    $uri = "$($GetFileInfo.Uri)/$($GetFileInfo.Name)";
+    $path = Join-Path $GetFileInfo.Path $GetFileInfo.Name
+    DownloadFile $GetFileInfo.Name $uri $path
+}
+
+function DownloadFile
+{
+    <#
+        .SYNOPSIS 
+            Downloads a file using the WebClient.
+
+        .DESCRIPTION
+            Downloads a file to a given path. This uses the System.Net.WebClient to perform the download which is fast, but also doesn't show any feedback as to the progress being made.
+        
+        .PARAMETER Name
+            The name of the file to download.
+        
+        .PARAMETER Url
+            The URI to download the file from.
+        
+        .PARAMETER Path
+            The path to download the file to.
+        
+        .EXAMPLE
+            DownloadFile -Name 'File.ext' -Url 'https://server.com/file.ext' -Path 'C:\temp\file.ext' 
+
+        .INPUTS
+            String
+        
+        .OUTPUTS
+            PSCustomObject
+    #>
+
+    param(
+        [Parameter(Mandatory)]
+        [String]$Name,
+        [Parameter(Mandatory)]
+        [String]$Uri,
+        [Parameter(Mandatory)]
+        [String]$Path
+    )
+
+    Write-Host "Downloading" $Name -ForegroundColor Cyan -NoNewLine; Write-Host " to:" $Path " ... " -NoNewline;
+    try {
+        (New-Object System.Net.WebClient).DownloadFile($Uri, $Path)
+        Write-Host "Done!" -ForegroundColor Green
+    } catch { Write-Host "Failed!" -ForegroundColor Red}
+}
+
+function LoadDump { 
+    param (
+        [Parameter(Mandatory)]
+        [PsObject] $dumpInfo
+    )
+    Write-Host "Loading " -NoNewLine; Write-Host $dumpInfo.Name -ForegroundColor Cyan -NoNewline; Write-Host " to: $($dumpInfo.Database)... ";
+    try{
+        $ignore = Invoke-Neo4jAdmin load --from="$($dumpInfo.Path)\$($dumpInfo.Name)" --database="$($dumpInfo.Database)" 
+        Write-Host "Loading " -NoNewLine; Write-Host $dumpInfo.Name -ForegroundColor Cyan -NoNewline; Write-Host " to: $($dumpInfo.Database)... " -NoNewline; Write-Host "Done!`n" -ForegroundColor Green
+    }catch {Write-Host "Failed!"    -ForegroundColor Red}
+}
+
+function CreateDumpDatabase { 
+    param (
+        [Parameter(Mandatory)]
+        [PsObject] $dumpInfo
+    )
+    
+    $results = "";
+    $isDropping = "";
+    Write-Host "Creating Database " -NoNewLine; Write-Host $dumpInfo.Database -ForegroundColor Cyan -NoNewline; Write-Host "..." -NoNewline
+    $cypherShell = Join-Path $neo4jLocation "bin\cypher-shell.bat" 
+    try {
+        $results = . $cypherShell -u neo4j -p $password -d system "CREATE DATABASE $($dumpInfo.Database);" 2>&1
+        if($results) {
+            Write-Host "`n`tUnexpected result when creating the '$($dumpInfo.Database)' database!!`n`t - '$($results)'" -ForegroundColor Red
+            Write-Host "You can drop the database and recreate it if you want. To do so, type '" -NoNewline; Write-Host "DROP" -ForegroundColor Cyan -NoNewline; Write-Host "' below (press ENTER otherwise)."
+            $response = Read-Host
+            if($response.ToLower() -eq "drop") {
+                  $isDropping = "yes"
+                  DropDatabase $dumpInfo 
+                  CreateDumpDatabase $dumpInfo
+            } else {
+                $isDropping = "no"
+                Write-Host "Creating Database " -NoNewLine; Write-Host $dumpInfo.Database -ForegroundColor Cyan -NoNewline; Write-Host "..." -NoNewline; Write-Host "Skipped" -ForegroundColor DarkYellow
+            }
+        }
+        if(!$isDropping){
+            Write-Host "Created" -ForegroundColor Green;
+        }
+    } catch { Write-Host "Failed!`n" + $_ -ForegroundColor Red }
+}
+
+function DropDatabase {    
+    param (
+        [Parameter(Mandatory)]
+        [PsObject] $dumpInfo
+    )
+    $result = "";
+    Write-Host "Dropping Database " -NoNewLine; Write-Host $dumpInfo.Database -ForegroundColor Cyan -NoNewline; Write-Host "..." -NoNewline
+    $cypherShell = Join-Path $neo4jLocation "bin\cypher-shell.bat"    
+    try{
+         $result = . $cypherShell -u neo4j -p $password -d system "DROP DATABASE $($dumpInfo.Database);"
+         if($result){
+             Write-Host "`n`tUnexpected result when dropping the '$($dumpInfo.Database)' database!!`n`t - '$($result)'" -ForegroundColor Red
+         }
+         Write-Host "Dropped" -ForegroundColor Green;
+    }catch {Write-Host "Failed!`n" + $_ -ForegroundColor Red}
+}
+
+function ValidateLoading {
+    param (
+        [Parameter(Mandatory)]
+        [PsObject] $dumpInfo
+    )
+    Write-Host "Verifying Database " -NoNewLine; Write-Host $dumpInfo.Database -ForegroundColor Cyan -NoNewline; Write-Host "..." -NoNewline
+    $cypherShell = Join-Path $neo4jLocation "bin\cypher-shell.bat"    
+    try{
+         $result = . $cypherShell -u neo4j -p $password -d $dumpInfo.Database "MATCH () RETURN count(*) AS actual;"
+         if($result[1] -eq $dumpInfo.ExpectedNodes){
+            Write-Host "Verified" -ForegroundColor Green -NoNewline; Write-Host " found $($result[1]) nodes.";
+         } else {
+            Write-Host "Unexpected number of Nodes, expected $($dumpInfo.ExpectedNodes) but got: $($result[1])" -ForegroundColor Red
+         }
+    }catch {Write-Host "Failed!`n" + $_ -ForegroundColor Red}
+}


### PR DESCRIPTION
* Added: a new `Setup-Windows-Single-Gds.ps1` script that allows you to setup a Neo4j instance and download and setup the Game Of Thrones and PaySim dumps
* Added: a new `downloadDumps.ps1` script to download and install the dumps
* Added: a new `functions.ps1` script to contain the shared functions between scripts
* Moved: the `DownloadFile` function from the `download.ps1` script to the `functions.ps1` script

I have tested them all locally, with no problems from moving the functions etc.